### PR TITLE
Updated ImageSharp to fix vulnerability

### DIFF
--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>QRCoder-ImageSharp</PackageId>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Authors>Raffael Herrmann, Joerg Plenert</Authors>
     <PackageOwners>Joerg Plenert</PackageOwners>
     <AssemblyName>QRCoder</AssemblyName>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+	<PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+	<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 

--- a/QRCoderTests/QRCoderTests.csproj
+++ b/QRCoderTests/QRCoderTests.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="shouldly" Version="4.2.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
 		<PackageReference Include="ZXing.Net" Version="0.16.9" />
 		<PackageReference Include="ZXing.Net.Bindings.ImageSharp.V2" Version="0.16.13" />
 		<ProjectReference Include="..\QRCoder\QRCoder.csproj" />		

--- a/QRCoderTests/QRCoderTests.csproj
+++ b/QRCoderTests/QRCoderTests.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="shouldly" Version="4.2.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
 		<PackageReference Include="ZXing.Net" Version="0.16.9" />
 		<PackageReference Include="ZXing.Net.Bindings.ImageSharp.V2" Version="0.16.13" />
 		<ProjectReference Include="..\QRCoder\QRCoder.csproj" />		


### PR DESCRIPTION
Fixes #5 

Also check https://www.nuget.org/packages/SixLabors.ImageSharp - 2.1.8 does not have any vulnerabilities reported currently